### PR TITLE
Adding 'tfvars' to triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ on:
   push:
     paths:
     - '**.tf'
+    - '**.tfvars'
 jobs:
   infracost:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This action runs [Infracost](https://github.com/aliscott/infracost) on the provi
 
 The AWS secrets mentioned below are used by terraform init and plan commands. As mentioned in the Infracost [repo readme](https://github.com/aliscott/infracost): you can run `infracost` in your terraform directories without worrying about security or privacy issues as no terraform secrets/tags/IDs etc are sent to the pricing service (only generic price-related attributes are used). Also, do not be alarmed by seeing the `terraform init` in output, no changes are made to your terraform or cloud resources. As a security precaution, read-only AWS IAM creds can be used.
 
+Standard Terraform env vars can also be added if required, e.g. `TF_CLI_ARGS`.
+
 ### `AWS_ACCESS_KEY_ID`
 
 **Required** AWS access key ID is used by terraform init and plan commands.


### PR DESCRIPTION
Most of the times, the flavors and size of resources are provided in 'tfvars' files, so it makes sense to run the pipeline when those files changes. We can also instruct the users in readme to put their `TF_CLI_ARGS` as an env for this step or we can change our entrypoint to support `var-files`.